### PR TITLE
Update Headers to work with RN 0.40

### DIFF
--- a/RNIntl/RNIntl.h
+++ b/RNIntl/RNIntl.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNIntl : NSObject <RCTBridgeModule>
 

--- a/lib/NumberFormat.js
+++ b/lib/NumberFormat.js
@@ -2,7 +2,6 @@
 
 const { RNIntl } = require('react-native').NativeModules;
 const BaseFormat = require('./BaseFormat');
-console.log(RNIntl);
 const DEFAULTS = {
   localeMatcher: 'best fit',
   style: 'decimal',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-intl",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "description": "React Native module shipped native Intl implementation and Translation extension",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update iOS Native Module header to work with React Native 0.40